### PR TITLE
Update and changes 3

### DIFF
--- a/after-the-interview.php
+++ b/after-the-interview.php
@@ -8,7 +8,7 @@ newsbox('After the interview', '<strong>*POSTING THE CONTENTS OF THIS INTERVIEW 
 <h2>You Passed!</h2>
 Hooray! Nice job answering all of those questions. After you log in, make sure you re-read and follow the Golden Rules. It is helpful to download the ' . $SITENAME . ' Toolbox (which is freeleech) for programs that most of us use. Then get going! Post in the forums, upload your own CD rips, chat with us in IRC, download music&#8230;
 <h2>You Failed!</h2>
-That stinks. Don&#8217;t worry, the interview is meant to be educational, which is why you have a total of three tries to pass the interview. Study up on this site and try again after 48 hours (2 days) have passed.<br /><br />
+That stinks. Don&#8217;t worry, the interview is meant to be educational, which is why you have a total of three tries to pass the interview. Study up on this site and try again after 24 hours have passed.<br /><br />
 If you have failed three times, you may not interview again. However, you may still be invited by a friend!');
 
 newsbot();

--- a/dupes-and-trumps.php
+++ b/dupes-and-trumps.php
@@ -1,0 +1,79 @@
+<? 
+	include('publicheader.php');
+	include('sidebar.php');
+
+newstop();
+
+newsbox(' Dupes & Trumps','
+<h3>Dupes, Releases, and Editions</h3>
+<h4>Releases</h4>
+Most albums have been pressed multiple times in slightly different ways. Any difference at all between two versions of the same album counts as a different release. You can find examples on sites like Discogs, where you\'ll typically find many different releases listed for a particular album. <br /><br />
+
+This of course applies to more than just albums, and extends in the same way to different pressings of singles, EP\'s, anthologies, etc. <br /><br />
+
+Not every unique release is allowed on ' . $SITENAME . '. Many releases are classified as dupes because while they have some differences, there are <strong>no meaningful differences in the audio content</strong>.  Only those releases which have meaningfully different audio content are allowed to co-exist on ' . $SITENAME . ', and we call them <strong>editions</strong>. <br /><br />
+
+<h4>Editions</h4>
+
+A different edition is where the audio content is <strong>significantly and meaningfully different</strong>.<br /><br />
+
+<strong>The determination of distinct editions for a CD goes beyond just catalog information</strong>. It relies on various factors such as rip log information, which includes the table of contents, peak levels, and pre-gaps. These details, along with the tracklist and running order, play a crucial role in differentiating one edition from another.<br /><br />
+
+<strong>While differences in catalog numbers, years of release, labels, countries of origin, or CD packaging may exist between CDs, they alone do not warrant the creation of a new and distinct edition</strong>.<br /><br />
+
+<h4>Dupes</h4>
+
+A dupe is when a new torrent is the same edition and same quality as an existing torrent. ' . $SITENAME . ' allows many different pressings of the same CD to coexist, as long the the CDs are distinct editions, meaning they have meaningfully different audio content.
+<br /><br />
+Torrents that have the same bitrates, formats, and comparable or identical sampling rates for the same edition are duplicates. If a torrent is already present on the site in the format and bitrate you wanted to upload, you are not allowed to upload it.
+<br /><br />
+For example, International Versions (especially Japanese releases) often have bonus tracks that are not present in the original release or the US release. Uploading a release with bonus tracks when the original release has already been uploaded is not considered a dupe because there is different content on both CDs.
+
+<ul>
+<li>Scene and non-scene torrents for the same release, in the same bitrate and format, are dupes.</li>
+<li>Torrents that have been inactive (not seeded) for two weeks may be trumped by the identical torrent (reseeded) or by a brand new rip or encode of the album. If you have the original torrent files for the inactive torrent, you should reseed those original files instead of uploading a new torrent.</li>
+</ul>
+<h3>Trumps</h3>
+The process of replacing a torrent that does not follow the rules with a torrent that does follow the rules is called <strong>trumping</strong>.<br />The most common trumps are format trumps, tag trumps, and folder trumps.
+
+<h3>Format Trumps</h3>
+The following chart shows the hierarchy of format trumps.
+<p style="text-align: center;"><a href="trumpchart.png" rel="lightbox[39]"><img title="Trump Chart" alt="" src="trumpchart.png" width="500" height="250" /></a></p>
+At the top of each column in a green box are formats that can never be trumped. We recommend that you only upload in these formats in order to prevent your torrents from being trumped by other users.<br />
+<strong>Lossy Format Trump Rules</strong>
+<ul>
+<li>If there is no existing torrent of the album in the allowed format you&#8217;ve chosen, you may upload it in any bitrate that averages at least 192 kbps.</li>
+<li>You may always upload MP3 V0 , MP3 V2, or MP3 320kbps (CBR) as long as another rip with the same bitrate and format doesn&#8217;t already exist.</li>
+<li>Higher bitrate CBR (Constant Bitrate) and ABR (Average Bitrate) torrents replace lower ones. Once a CBR rip has been uploaded, no CBR rips of that bitrate or lower can be uploaded. In the same manner, once an ABR rip has been uploaded, no ABR rips of that bitrate or lower can be uploaded.</li>
+<li>AAC encodes can be trumped by any allowed MP3 format of the same edition and media. (This does not apply to AAC torrents with files bought from the iTunes Store that contain iTunes Exclusive tracks.)</li>
+<li>Lossy format torrents with .log files, .cue files, .m3u files, and album artwork do not replace equivalent existing torrents.</li>
+</ul>
+<strong>Lossless Format Trump Rules</strong>
+<ul>
+<li>Rips must be taken from commercially pressed or official (artist- or label-approved) CD sources. They may not come from CD-R copies of the same pressed CDs (unless the release was only distributed on CD-R by the artist or label).</li>
+<li>A FLAC torrent without a log (or with a log from a non-EAC or non-XLD ripping tool like dBpoweramp or Rubyripper) may be trumped by a FLAC torrent with a log from an approved ripping tool with any score.</li>
+<li>A FLAC upload with an EAC or XLD log that scores 100% on the log checker replaces one with a lower score. However, no log scoring less than 100% can trump an already existing one that scores under 100% (for example, a rip with a 99% log cannot replace a rip with an 80% log).</li>
+<li>A 100% log rip without a cue sheet can be replaced by a 100% log rip with a noncompliant cue sheet ONLY when the included cue sheet is materially different from &#8220;a cue generated from the ripping log.&#8221; Examples of a material difference include additional or correct indices, properly detected pre-gap lengths, and pre-emphasis flags.</li>
+</ul>
+<h3>Tag Trumps</h3>
+<strong>Tag trumps</strong> happen when the original torrent either doesn&#8217;t have the required tag fields or the information in one of the tag fields is completely wrong or misspelled. In the case of misspelled words, the spelling must be entirely off in order for the tag trump to be considered (for example, missing prepositions like &#8220;the&#8221; or &#8220;a&#8221;, or a couple letters being in the wrong order like &#8220;lvoe&#8221; instead of &#8220;love&#8221; is not enough for a tag trump).
+<ul>
+<li>The required tag fields are: title, album, artist, track number.</li>
+<li>Torrent album titles must accurately reflect the actual album titles. Use proper capitalization when naming your albums. Typing the album titles in all lowercase letters or all capital letters is unacceptable and makes the torrent trumpable.</li>
+<li>Newly re-tagged torrents trumping badly tagged torrents must reflect a substantial improvement over the previous tags. Small changes that include replacing ASCII characters with proper foreign language characters with diacritical marks (<em>&#225;, &#233;, &#237;, &#243;, &#250;</em>, etc.), fixing slight misspellings, or missing an alternate spelling of an artist (excluding &#8220;The&#8221; before a band name) are not enough for replacing other torrents.</li>
+</ul>
+<h3>Folder Trumps</h3>
+<strong>Folder trumps</strong> happen when the original torrent&#8217;s folder is not named like it should be. Folders should at the very least include the album name, but should hopefully also include the year released and music format. Nested folders are also not allowed.
+<ul>
+<li>Music releases must be in a directory that contains the music. This includes single track releases, which must be enclosed in a torrent folder even if there is only one file in the torrent. No music may be compressed in an archive (.rar, .zip, .tar, .iso).</li>
+<li>Name your directories with meaningful titles, such as &#8220;Artist &#8211; Album (Year) &#8211; Format.&#8221; The minimum acceptable is &#8220;Album&#8221; although you should include more information.</li>
+<li>Avoid creating unnecessary nested folders (such as an extra folder for the actual album) inside your properly named directory.</li>
+<li>File names must accurately reflect the song titles. You may not have file names like 01track.mp3, 02track.mp3, etc. Torrents containing files that are named with incorrect song titles can be trumped by properly labeled torrents.</li>
+<li>Multiple-disc torrents cannot have tracks with the same numbers in one directory. You may place all the tracks for Disc One in one directory and all the tracks for Disc Two in another directory.</li>
+</ul>
+');
+
+newsbot();
+
+	include('publicfooter.php'); 
+?>

--- a/faq.php
+++ b/faq.php
@@ -1,0 +1,48 @@
+<? 
+	include('publicheader.php');
+	include('sidebar.php');
+
+newstop();
+
+newsbox('FAQ', '
+<ul style="list-style: none; padding-left: 0;"><li><strong>Q: How do I queue for an interview?</strong></li>
+<li>A: In #recruitment type: <strong>"/msg hermes !queue https://www.speedtest.net/result/123456789.png"</strong>.</li>
+<br>
+<li><strong>Q: When will interview open and how long does one interview take?</strong></li>
+<li>A: Interviews are open from saturday 00:00 UTC to sunday 23:59 UTC and it takes around 80 minutes.</li>
+<br>
+<li><strong>Q: How do I leave the queue? Is there any penalty for leaving before my interview starts?</strong></li>
+<li>A: You can remove yourself from the queue by leaving the #recruitment channel or typing  <strong>"/msg hermes !cancel" </strong>. There is no penalty for leaving the queue at any time. </li>
+<br>
+<li><strong>Q: Do I lose my position in the queue when I leave #recruitment? / I was disconnected while in the queue. Do I have to queue again?</strong></li>
+<li>A: Yes. Please requeue using a fresh speedtest.</li>
+<br>
+<li><strong>Q: Can I hang out in #recruitment without queuing?</strong></li>
+<li>A: No. This channel is only for people that wish to interview. </li>
+<br>
+<li><strong>Q: What kinds of questions are asked during the interview?</strong></li>
+<li>A: Everything mentioned on our site <a href="https://interview.orpheus.network/" target="_blank">https://interview.orpheus.network/</a>.</li>
+<br>
+<li><strong>Q: How many questions can I get wrong? Do I have to get 100%?</strong></li>
+<li>A: You do not have to get every question right. It depends on which questions you miss, as some topics are more important than others.</li>
+<br>
+<li><strong>Q: Can I refer to the interview prep website during the interview? What about my own notes?</strong></li>
+<li>A: No. No notes or references of any kind are allowed during the interview.</li>
+<br>
+<li><strong>Q: What if my interview starts while I am away? </strong></li>
+<li>A: You have 15 minutes to respond. Any longer is up to the discretion of your interviewer. </li>
+<br>
+<li><strong>Q: What if I need to step away for a little while during the interview?</strong></li>
+<li>A: Let your interviewer know how long you need, and they will let you know if it\'s OK.</li>
+<br>
+<li><strong>Q: Can I use a VPN connection for the interview? Can I interview on my phone or other mobile device?</strong></li>
+<li>A: No. You must physically be at home and on your home connection in order to be allowed to be interviewed.</li>
+<br>
+<li><strong>Q: Someone behind me in the queue just started the interview. Why was I skipped?</strong></li>
+<li>A: You need to be connected on port <strong>7000</strong> to join the interview. Interviewers also cannot interview the same candidate more than once.</li></ul>
+');
+
+newsbot();
+
+	include('publicfooter.php'); 
+?>

--- a/orpheus-rules.php
+++ b/orpheus-rules.php
@@ -34,7 +34,7 @@ newsbox('Golden rules of ' . $SITENAME,'<p>The Golden Rules encompass all of ' .
 <li>Reporting incorrect data to the tracker constitutes cheating, whether it is accomplished through the use of a modified "cheat client" or through manipulation of an approved client.</li>
 <li><p>3.3</p></li>
 <li><strong>Do not use unapproved clients.</strong></li>
-<li>Your client must be listed on the Client Whitelist. You must not use clients that have been modified in any way. Developers interested in testing unstable clients must receive staff approval prior to testing.</li>
+<li>Your client must be listed on the Client Whitelist. You must not use clients that have been modified in any way. Developers interested in clients that have been modified in any way. Do not use a client you do not have direct and exclusive access to. Developers interested in testing unstable clients must receive staff approval prior to testing.</li>
 <li><p>3.4</p></li>
 <li><strong>Do not modify Orpheus .torrent files.</strong></li>
 <li>Embedding non-Orpheus announce URLs in Orpheus .torrents is prohibited. Doing so causes false data to be reported and will be interpreted as cheating. This applies to standalone .torrent files and .torrent files that have been loaded into a client.</li>

--- a/orpheus-rules.php
+++ b/orpheus-rules.php
@@ -4,72 +4,88 @@
 
 newstop();
 
-newsbox($SITENAME .' rules','<p>The Golden Rules on ' . $SITENAME . ' are as follows:</p>
-<ul>
-<li><strong>All staff decisions must be respected.</strong> If you take issue with a decision, you must do so privately with the staff member who issued the decision or with an administrator of the site. Complaining about staff decisions in public or otherwise disrespecting staff members will not be taken lightly.</li>
-<li><strong>Access to this website is a privilege, not a right, and it can be taken away from you for any reason.</strong></li>
-<li><strong>One account per person per lifetime. Anyone creating additional accounts will be banned.</strong></li>
-<li>Avatars must not exceed 256 kB or be vertically longer than 400 pixels. Avatars must be safe for work, be entirely unoffensive, and cannot contain any nudity or religious imagery. Use common sense.</li>
-<li>Do not post our .torrent files on other sites. Every .torrent file has your personal passkey embedded in it. The tracker will automatically disable your account if you share your torrent files with others. You will not get your account back. This doesn&#8217;t prohibit you from sharing the content on other sites, but does prohibit you from sharing the .torrent file.</li>
-<li>Any torrent you are seeding to this tracker must only have our tracker&#8217;s URL in it. Adding another tracker&#8217;s URL will cause incorrect data to be sent to our tracker, and will lead to your getting disabled for cheating. Similarly, your client must have DHT and PEX disabled for all ' . $SITENAME . ' torrents.</li>
-<li>This is a torrent site which promotes sharing amongst the community. If you are not willing to give back to the community what you take from it, this site is not for you. In other words, we expect you to have an acceptable share ratio. If you download a torrent, please, seed the copy you have until there are sufficient people seeding the torrent data before you stop.</li>
-<li><strong>Do not browse the site using proxies or TOR. The site will automatically alert us. This includes VPNs with dynamic IP addresses. Dedicated IP addresses for VPNs are OK.</strong></li>
-<li>Asking for invites to any site is not allowed anywhere on ' . $SITENAME . ' or our IRC network. Invites may be offered in the Invites forum, and nowhere else.</li>
-<li><strong>Trading and selling invites is strictly prohibited, as is offering them in public</strong> &#8211; this includes on any forum which is not a class-restricted section on an invitation-only torrent site.</li>
-<li><strong>Trading, selling, sharing, or giving away your account is prohibited. </strong>PM a mod to disable your account if you no longer want it.</li>
-<li>You&#8217;re completely responsible for the people you invite. If your invitees are caught cheating or trading/selling invites, not only will they be banned, so will you. Be careful who you invite. Invites are a precious commodity.</li>
-<li>Be careful when sharing an IP or a computer with a friend if they have (or have had) an account. From then on your accounts will be inherently linked and if one of you violates the rules, both accounts will be disabled along with any other accounts linked by IP. This rule applies to logging into the site.</li>
-<li><strong>Attempting to find or exploit a bug in the site code is the worst possible offense you can commit.</strong> We have automatic systems in place for monitoring these activities, and committing them will result in the banning of you, your inviter, and your inviter&#8217;s entire invite tree.</li>
-<li>We&#8217;re a community. Working together is what makes this place what it is. There are well over a thousand new torrents uploaded every day and sadly the staff aren&#8217;t psychic. If you come across something that violates a rule, report it and help us better organize the site for you.</li>
-<li>We respect the wishes of other sites here, as we wish for them to do the same. Please refrain from posting links to or full names for sites that do not want to be mentioned.</li>
-</ul>
-<h3>Dupes</h3>
-A <strong>dupe</strong> is a torrent that is a duplicate of another torrent that already exists on the site. ' . $SITENAME . ' allows many different pressings of the same CD to coexist, as long the the CDs have different content.<br /><br />
-For example, International Versions (especially Japanese releases) often have bonus tracks that are not present in the original release or the US release. Uploading a release with bonus tracks when the original release has already been uploaded is not considered a dupe because there is different content on both CDs.
-<ul>
-<li>Torrents that have the same bitrates, formats, and comparable or identical sampling rates for the same music release are duplicates. If a torrent is already present on the site in the format and bitrate you wanted to upload, you are not allowed to upload it.</li>
-<li>Scene and non-scene torrents for the same release, in the same bitrate and format, are dupes.</li>
-<li>Rip log information (table of contents, peak levels, and pre-gaps), tracklist, and running order determine distinct editions, not catalog information<strong>.</strong> Merely having different catalog numbers or CD packaging is not enough to justify a new, distinct edition, though differences in year and label (imprint) do determine distinct releases.</li>
-<li>Torrents that have been inactive (not seeded) for two weeks may be trumped by the identical torrent (reseeded) or by a brand new rip or encode of the album. If you have the original torrent files for the inactive torrent, you should reseed those original files instead of uploading a new torrent.</li>
-</ul>
-<h3>Trumps</h3>
-The process of replacing a torrent that does not follow the rules with a torrent that does follow the rules is called <strong>trumping</strong>.<br />The most common trumps are format trumps, tag trumps, and folder trumps.
-
-<h3>Format Trumps</h3>
-The following chart shows the hierarchy of format trumps.
-<p style="text-align: center;"><a href="trumpchart.png" rel="lightbox[39]"><img title="Trump Chart" alt="" src="trumpchart.png" width="500" height="250" /></a></p>
-At the top of each column in a green box are formats that can never be trumped. We recommend that you only upload in these formats in order to prevent your torrents from being trumped by other users.<br />
-<strong>Lossy Format Trump Rules</strong>
-<ul>
-<li>If there is no existing torrent of the album in the allowed format you&#8217;ve chosen, you may upload it in any bitrate that averages at least 192 kbps.</li>
-<li>You may always upload MP3 V0 , MP3 V2, or MP3 320kbps (CBR) as long as another rip with the same bitrate and format doesn&#8217;t already exist.</li>
-<li>Higher bitrate CBR (Constant Bitrate) and ABR (Average Bitrate) torrents replace lower ones. Once a CBR rip has been uploaded, no CBR rips of that bitrate or lower can be uploaded. In the same manner, once an ABR rip has been uploaded, no ABR rips of that bitrate or lower can be uploaded.</li>
-<li>AAC encodes can be trumped by any allowed MP3 format of the same edition and media. (This does not apply to AAC torrents with files bought from the iTunes Store that contain iTunes Exclusive tracks.)</li>
-<li>Lossy format torrents with .log files, .cue files, .m3u files, and album artwork do not replace equivalent existing torrents.</li>
-</ul>
-<strong>Lossless Format Trump Rules</strong>
-<ul>
-<li>Rips must be taken from commercially pressed or official (artist- or label-approved) CD sources. They may not come from CD-R copies of the same pressed CDs (unless the release was only distributed on CD-R by the artist or label).</li>
-<li>A FLAC torrent without a log (or with a log from a non-EAC or non-XLD ripping tool like dBpoweramp or Rubyripper) may be trumped by a FLAC torrent with a log from an approved ripping tool with any score.</li>
-<li>A FLAC upload with an EAC or XLD log that scores 100% on the log checker replaces one with a lower score. However, no log scoring less than 100% can trump an already existing one that scores under 100% (for example, a rip with a 99% log cannot replace a rip with an 80% log).</li>
-<li>A 100% log rip without a cue sheet can be replaced by a 100% log rip with a noncompliant cue sheet ONLY when the included cue sheet is materially different from &#8220;a cue generated from the ripping log.&#8221; Examples of a material difference include additional or correct indices, properly detected pre-gap lengths, and pre-emphasis flags.</li>
-</ul>
-<h3>Tag Trumps</h3>
-<strong>Tag trumps</strong> happen when the original torrent either doesn&#8217;t have the required tag fields or the information in one of the tag fields is completely wrong or misspelled. In the case of misspelled words, the spelling must be entirely off in order for the tag trump to be considered (for example, missing prepositions like &#8220;the&#8221; or &#8220;a&#8221;, or a couple letters being in the wrong order like &#8220;lvoe&#8221; instead of &#8220;love&#8221; is not enough for a tag trump).
-<ul>
-<li>The required tag fields are: title, album, artist, track number.</li>
-<li>Torrent album titles must accurately reflect the actual album titles. Use proper capitalization when naming your albums. Typing the album titles in all lowercase letters or all capital letters is unacceptable and makes the torrent trumpable.</li>
-<li>Newly re-tagged torrents trumping badly tagged torrents must reflect a substantial improvement over the previous tags. Small changes that include replacing ASCII characters with proper foreign language characters with diacritical marks (<em>&#225;, &#233;, &#237;, &#243;, &#250;</em>, etc.), fixing slight misspellings, or missing an alternate spelling of an artist (excluding &#8220;The&#8221; before a band name) are not enough for replacing other torrents.</li>
-</ul>
-<h3>Folder Trumps</h3>
-<strong>Folder trumps</strong> happen when the original torrent&#8217;s folder is not named like it should be. Folders should at the very least include the album name, but should hopefully also include the year released and music format. Nested folders are also not allowed.
-<ul>
-<li>Music releases must be in a directory that contains the music. This includes single track releases, which must be enclosed in a torrent folder even if there is only one file in the torrent. No music may be compressed in an archive (.rar, .zip, .tar, .iso).</li>
-<li>Name your directories with meaningful titles, such as &#8220;Artist &#8211; Album (Year) &#8211; Format.&#8221; The minimum acceptable is &#8220;Album&#8221; although you should include more information.</li>
-<li>Avoid creating unnecessary nested folders (such as an extra folder for the actual album) inside your properly named directory.</li>
-<li>File names must accurately reflect the song titles. You may not have file names like 01track.mp3, 02track.mp3, etc. Torrents containing files that are named with incorrect song titles can be trumped by properly labeled torrents.</li>
-<li>Multiple-disc torrents cannot have tracks with the same numbers in one directory. You may place all the tracks for Disc One in one directory and all the tracks for Disc Two in another directory.</li>
-</ul>
+newsbox('Golden rules of ' . $SITENAME,'<p>The Golden Rules encompass all of ' . $SITENAME . ' and our IRC Network. These rules are paramount non-compliance will jeopardize your account. </p>
+<ul style="list-style: none; padding-left: 0;"><li><p>1.1</p></li>
+<li><strong>One account per person, per lifetime.</strong></li>
+<li>Users are allowed one account per lifetime. If your account is disabled, contact staff in #disabled on IRC. Never make another account, you will be disabled without question.</li>
+<li><p>1.2</p></li>
+<li><strong>Do not trade, sell, give away, or offer accounts.</strong></li>
+<li>If you no longer wish to use your account, send a Staff PM and request that your account be disabled.</li>
+<li><p>1.3</p></li>
+<li><strong>Do not share accounts.</strong></li>
+<li>Accounts are for personal use only. Granting access to your account in any way (e.g., shared login details, external programs) is prohibited. Invite friends or direct them to the interview channel (#recruitment).</li>
+<li><p>1.4</p></li>
+<li><strong>Do not let your account become inactive.</strong></li>
+<li>You agree to log into the site regularly in order to keep your account in good standing. Failure to do so will result in your account being disabled. See Account Inactivity for more information.</li>
+<li><p>2.1</p></li>
+<li><strong>Do not invite bad users.</strong></li>
+<li>You are responsible for your invitees. You will not be punished if your invitees fail to maintain required share ratios, but invitees who break golden rules will place your invite privileges and account at risk.</li>
+<li><p>2.2</p></li>
+<li><strong>Do not trade, sell, publicly give away, or publicly offer invites.</strong></li>
+<li>Only invite people you know and trust. Do not offer invites via other trackers, forums, social media, or other public locations. Responding to public invite requests is prohibited. Exception: Staff-designated recruiters may offer invites in approved locations.</li>
+<li><p>2.3</p></li>
+<li><strong>Do not request invites or accounts.</strong></li>
+<li>Requesting invites to—or accounts on—Orpheus or other trackers is prohibited. Invites may be offered, but not requested, in the Invites forum (restricted to the Elite class and above). You may request invites by messaging users only when they have offered them in the Invites Forum. Unsolicited invite </li>requests, even by private message, are prohibited.
+<li><p>3.1</p></li>
+<li><strong>Do not engage in ratio manipulation.</strong></li>
+<li>Transferring buffer—or increasing your buffer—through unintended uses of the BitTorrent protocol or site features (e.g., request abuse) constitutes ratio manipulation. When in doubt, send a Staff PM asking for more information.</li>
+<li><p>3.2</p></li>
+<li><strong>Do not report incorrect data to the tracker (i.e., cheating).</strong></li>
+<li>Reporting incorrect data to the tracker constitutes cheating, whether it is accomplished through the use of a modified "cheat client" or through manipulation of an approved client.</li>
+<li><p>3.3</p></li>
+<li><strong>Do not use unapproved clients.</strong></li>
+<li>Your client must be listed on the Client Whitelist. You must not use clients that have been modified in any way. Developers interested in testing unstable clients must receive staff approval prior to testing.</li>
+<li><p>3.4</p></li>
+<li><strong>Do not modify Orpheus .torrent files.</strong></li>
+<li>Embedding non-Orpheus announce URLs in Orpheus .torrents is prohibited. Doing so causes false data to be reported and will be interpreted as cheating. This applies to standalone .torrent files and .torrent files that have been loaded into a client.</li>
+<li><p>3.5</p></li>
+<li><strong>Do not share .torrent files or your passkey.</strong></li>
+<li>Embedded in each Orpheus .torrent file is an announce URL containing your personal passkey. Passkeys enable users to report stats to the tracker.</li>
+<li><p>4.1</p></li>
+<li><strong>Do not blackmail, threaten, or expose fellow users or staff.</strong></li>
+<li>Exposing or threatening to expose private information about users for any reason is prohibited. Private information includes, but is not limited to, personally identifying information (e.g., names, records, biographical details, photos). Information that has not been openly volunteered by a user should not </li>be discussed or shared without permission. This includes private information collected via investigations into openly volunteered information (e.g., Google search results).
+<li><p>4.2</p></li>
+<li><strong>Do not scam or defraud.</strong></li>
+<li>Scams (e.g., phishing) of any kind are prohibited.</li>
+<li><p>4.3</p></li>
+<li><strong>Do not disrespect staff decisions.</strong></li>
+<li>Disagreements must be discussed privately with the deciding moderator. If the moderator has retired or is unavailable, you may send a Staff PM. Do not contact multiple moderators hoping to find one amenable to your cause; however, you may contact a site administrator if you require a second opinion. Options </li>for contacting staff include private message, Staff PM, and #help on IRC.
+<li><p>4.4</p></li>
+<li><strong>Do not impersonate staff.</strong></li>
+<li>Impersonating staff or official service accounts (e.g., Hermes) on-site, off-site, or on IRC is prohibited. Deceptively misrepresenting staff decisions is also prohibited.</li>
+<li><p>4.5</p></li>
+<li><strong>Do not backseat moderate.</strong></li>
+<li>"Backseat moderation" occurs when users police other users. Confronting, provoking, or chastising users suspected of violating rules—or users suspected of submitting reports—is prohibited. Submit a report if you see a rule violation.</li>
+<li><p>4.6</p></li>
+<li><strong>Do not request special events.</strong></li>
+<li>Special events (e.g., freeleech, neutral leech, picks) are launched at the discretion of the staff. They do not adhere to a fixed schedule, and may not be requested by users.</li>
+<li><p>4.7</p></li>
+<li><strong>Do not harvest user-identifying information.</strong></li>
+<li>It is prohibited to use Orpheus\'s services to harvest user-identifying information of any kind (e.g., IP addresses, personal links) through the use of scripts, exploits, or other techniques.</li>
+<li><p>4.8</p></li>
+<li><strong>Do not use Orpheus\'s services (including the tracker, website, and IRC network) for commercial gain.</strong></li>
+<li>Commercializing services provided by or code maintained by Orpheus (e.g., Gazelle, Ocelot) is prohibited. Commercializing content provided by Orpheus users via the aforementioned services (e.g., user torrent data) is prohibited. Referral schemes, financial solicitations, and money offers are also prohibited.</li>
+<li><p>5.1</p></li>
+<li><strong>Do not browse Orpheus using any free proxy or VPN service.</strong></li>
+<li>You may browse the site through a VPN/proxy only if you have paid for this service. This includes (for example) self-hosted VPNs or proxies, services like NordVPN and VPNs or proxies that come with a seedbox. When in doubt, please send a Staff PM. The use of Tor for browsing the site is not allowed.</li>
+<li><p>5.2</p></li>
+<li><strong>Do not abuse automated site access.</strong></li>
+<li>All automated site access must be done through the API. API use is limited to 5 requests within any 10-second window. Scripts and other automated processes must not scrape the site\'s HTML pages. When in doubt, seek advice from staff.</li>
+<li><p>5.3</p></li>
+<li><strong>Do not autosnatch freeleech torrents.</strong></li>
+<li>The automatic snatching of freeleech torrents using any method involving little or no user-input (e.g., API-based scripts, log or site scraping, etc.) is prohibited. See Orpheus\'s Freeleech Autosnatching Policy article for more information.</li>
+<li><p>6.1</p></li>
+<li><strong>Do not seek or exploit live bugs for any reason.</strong></li>
+<li>Seeking or exploiting bugs in the live site (as opposed to a local development environment) is prohibited. If you discover a critical bug or security vulnerability, immediately report it in accordance with Orpheus\'s Responsible Disclosure Policy. Non-critical bugs can be reported in the Bugs Forum.</li>
+<li><p>6.2</p></li>
+<li><strong>Do not publish exploits.</strong></li>
+<li>The publication, organization, dissemination, sharing, technical discussion, or technical facilitation of exploits is prohibited at staff discretion. Exploits are defined as unanticipated or unaccepted uses of internal, external, non-profit, or for-profit services. Exploits are subject to reclassification </li>at any time.
+<li><p>7.0</p></li>
+<li><strong>Be respectful to all staff members.</strong></li>
+<li>Staff on Orpheus are volunteers who dedicate their time in order to keep the site running, while receiving no compensation. Being disrespectful to them is prohibited, and might result in a warning or a ban.</li>
+<li><p>7.1</p></li>
+<li><strong>Staff have the final word on rule interpretations.</strong></li>
+<li>All rules on Orpheus may be subject to different interpretations. Since the staff wrote these rules, their interpretation is final. If you need clarification on a rule, or if you think a rule should be restated, please send a Staff PM.</li></ul>
 ');
 
 newsbot();

--- a/preparefortheinterview.php
+++ b/preparefortheinterview.php
@@ -14,6 +14,7 @@ In order to receive an invite to ' . $SITENAME . ', you must pass our interview.
 <li><a title="Torrenting" href="torrenting.php" target="_blank"><strong>Torrenting</strong></a> &mdash; BitTorrent vocabulary, ratio, and more!</li>
 <li><a title="Spectral Analysis" href="spectral-analysis.php" target="_blank"><strong>Spectral Analysis</strong></a> &mdash; The best way to determine the bitrate of an unknown music file. (Pretty pictures!)</li>
 <li><a title="CD Burning and CD Ripping" href="cd-burning-and-cd-ripping.php" target="_blank"><strong>CD Burning and CD Ripping</strong> </a> &mdash; How to make the best possible CD rip.</li>
+<li><a title="' . $SITENAME . ' Rules" href="dupes-and-trumps.php" target="_blank"><strong>Dupes & Trumps</strong></a> &mdash; What is dupe and what can you trump</li>
 <li><a title="' . $SITENAME . ' Rules" href="orpheus-rules.php" target="_blank"><strong>' . $SITENAME . ' Rules</strong></a> &mdash; Break them and perish.</li>
 </ol>
 Luckily, everything you need to know is right on this site! Make sure you carefully read through all of the pages under the Knowledge menu before you even think of queuing in ' . $interviewchan . '. Take notes if you wish, however, you may <strong>NOT</strong> use these notes while taking an interview.');

--- a/sidebar.php
+++ b/sidebar.php
@@ -10,6 +10,7 @@
 <a href="preparefortheinterview.php">Prepare for the Interview</a><br />
 <a href="starting-the-interview.php">Starting the Interview</a><br />
 <a href="after-the-interview.php">After the Interview</a><br />
+<a href="faq.php">FAQ</a><br />
 		</div>
 	</div>
 
@@ -27,7 +28,8 @@
 <a href="torrenting.php">Torrenting</a><br />
 <a href="spectral-analysis.php">Spectral analysis</a><br />
 <a href="cd-burning-and-cd-ripping.php">CD burning and CD ripping</a><br />
-<a href="orpheus-rules.php"><?=$SITENAME?> rules</a><br />
+<a href="dupes-and-trumps.php">Dupes & Trumps</a><br />
+<a href="orpheus-rules.php">Golden rules of <?=$SITENAME?></a><br />
 		</div>
 	</div>
 

--- a/starting-the-interview.php
+++ b/starting-the-interview.php
@@ -16,10 +16,11 @@ newsbox('Starting the interview', '
 Once you are all set up, read on!
 
 <h3>Connecting to ' . $SITENAME . '&#8217;s IRC</h3>
+<h4><strong>INTERVIEWS ARE OPEN FROM SATURDAY 00:00 UTC TO SUNDAY 23:59 UTC.</strong></h4>
 <strong>YOU MAY ONLY INTERVIEW ON YOUR HOME CONNECTION. Proxies, bouncers, shells, office lines, and other non-home connections (including using your friend&#8217;s home connection) are not allowed. You may connect from your university dormitory.<br />
 </strong><br /><br />
 <strong>IRC Server:</strong> irc.orpheus.network<br />
-<strong>Port:</strong> 6667 (+7000 for SSL)<br /><br />
+<strong>Port:</strong> 7000<br /><br />
 
 After you have connected to ' . $SITENAME . '&#8217;s IRC network, type: &#8220;/join ' . $interviewchan . '&#8221; (without the quotation marks) and follow the directions in the topic.
 

--- a/transcodes.php
+++ b/transcodes.php
@@ -7,23 +7,16 @@ newstop();
 newsbox('Transcodes', '
 <strong>Transcoding (verb)</strong> a file means converting from one format to another. A <strong>transcode (noun)</strong> can mean any converted file, but is usually used in a negative context (as in a bad transcode).
 <h3>Good Transcodes</h3>
-A <strong>good transcode</strong> means that during the transcode process, the file has either never been converted to lossy, or the file has only been converted to lossy once during the last step.
+A <strong>good transcode</strong> means that during the transcode process, the file has been converted to any other lossless format, or the file has either never been converted to lossy, or the file has only been converted to lossy once during the last step.
 <br />
-<p>Examples of good transcodes:</p>
-<ul>
-<li>uncompressed lossless &gt; compressed lossless</li>
-<li>compressed lossless &gt; uncompressed lossless</li>
-<li>compressed lossless &gt; compressed lossless</li>
-<li>uncompressed lossless &gt; lossy</li>
-<li>compressed lossless &gt; lossy</li>
-</ul>
+
 <h3>Bad Transcodes</h3>
 A <strong>bad transcode</strong> means that during the transcode process, the file has either been converted to a lossy format more than once, or the file has been converted from lossy to lossless. <strong>Bad transcodes are prohibited on ' . $SITENAME . '.</strong>
-<p>Examples of bad transcodes:</p>
-<ul>
-<li>higher lossy bitrate &gt; lower lossy bitrate</li>
-<li>same bitrate lossy &gt; same bitrate lossy</li>
-<li>lossy &gt; lossless</li>
+<br />
+<hr>
+<li style="color: lime;">Transcodes from lossless to lossless are always OK.</li>
+<li><span style="color: lime;">A transcode from lossless to lossy is OK</span><span  style="color: red;">, but any further transcode of the lossy file is bad.</span></li>
+<li style="color: red;">Any transcode from a lossy source is a bad transcode, period. (lossy to lossy or lossy to lossless).</li>
 </ul>');
 
 newsbot();


### PR DESCRIPTION
1) Changed after-the-interview.php. From 48 hours waiting time to 24 hours.
2) Created FAQ.php. Inspired/copied by RED. Some questions removed and changed to fit our site.
3) Changed starting-the-interview.php. Added that interviews are open only in the weekend and that you should only connect on port 7000
4) Changed transcodes.php. Removed the previous examples and added new ones with colour codes.
5) Changed sidebar.php. Added links to FAQ, and newly split orpheus rules and dupes & trumps.
6) Changed preparefortheinterview.php. Added the new split orpheus rules and dupes & trumps.
7) Changed orpheus-rules.php. Copies all golden rules from the page and pasted them here.
8) Created dupes-and-trumps.php. Was previously in orpheus-rules.php. Trump section will remain unchanged for now. Dupe section is still in works?